### PR TITLE
Fix: All layers show on edit mode active

### DIFF
--- a/frontend/mapEditTools.js
+++ b/frontend/mapEditTools.js
@@ -10,6 +10,7 @@ const Icon = require("./tools/icon");
 const Polygon = require("./tools/polygon");
 const Line = require("./tools/line");
 const Scissor = require("./tools/scissor");
+const LayerGroup = require("ol/layer/Group").default
 
 
 class EditTools {
@@ -135,14 +136,15 @@ class EditTools {
             this.editMode = newMode
             if (this.editMode) {
                 this.emit(this.EVENT_EDIT_MODE_ENABLED)
-                const editLayerTitles = [ 'Custom Areas', 'Train Lines', this.facilitiesGroup.get('title')]
-                for (const layer of Object.values(this.iconTools)) {
-                    editLayerTitles.push(layer.title)
+                const editLayerTitles = [ 'Custom Areas', 'Train Lines', this.facilitiesGroup.get('title'), ...Object.keys(this.iconTools).map((key) => { return this.iconTools[key].title})]
+                const nestVisibleTrue = (layer) => {
+                    if (layer instanceof LayerGroup) {
+                        layer.getLayers().forEach((subLayer) => { nestVisibleTrue(subLayer) })
+                    }
+                    layer.setVisible(true)
                 }
                 this.map.getLayers().forEach((layer) => {
-                    if (editLayerTitles.includes(layer.get('title'))) {
-                        layer.setVisible(true)
-                    }
+                    if (editLayerTitles.includes(layer.get('title'))) { nestVisibleTrue(layer) }
                 })
             }
             else {


### PR DESCRIPTION
I mistakenly only applied setVisible to parents and did not notice that it does not propagate to children. This was fine for layers with no children but would not set visibility of LayerGroup children unless the page was reloaded.

This [2cd483329dc417ac3ce233ee812c4e7c1e29a172] change adds a recursive loop that will set layers, LayerGroups and LayerGroups children to true on edit mode activation. 