### PR TITLE
Picture-In-Picture Support for Stats page

### DIFF
--- a/frontend/consts.css
+++ b/frontend/consts.css
@@ -1,0 +1,23 @@
+@property --primary {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #245784;
+}
+
+@property --border-light {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #dadfe4;
+}
+
+@property --border-dark {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #364049;
+}
+
+@property --copy-dark {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #fbfbfc;
+}

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -4,14 +4,74 @@
 @import "ol-ext/control/Search.css";
 @import "bootstrap-icons/font/bootstrap-icons.css";
 @import "tom-select/src/scss/tom-select.bootstrap5.scss";
+@import url("./consts.css");
+
+:root {
+  color-scheme: light dark;
+}
 
 #map .layer-switcher {
   top: 0.5em;
   color: $black;
 }
 
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  width: 100dvw;
+  color: white;
+  background-color: rgba(33, 37, 41, 1)
+}
+
 main {
   position: relative;
+  height: calc(100% - 3.5rem);
+
+  @media (display-mode: picture-in-picture) {
+    height: 100%;
+  }
+}
+
+#pip-button {
+  all: unset;
+  cursor: pointer;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: light-dark(var(--border-light), var(--border-dark));
+  background-color: var(--primary);
+  padding: 0.5rem;
+  display: none;
+  position: absolute;
+  color: var(--copy-dark);
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 100;
+  opacity: 0.6;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition-property: all;
+    transition-duration: 150ms;
+    transition-timing-function: ease-in-out;
+    transition-behavior: allow-discrete;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &[data-supported] {
+    display: flex;
+
+    @media (display-mode: picture-in-picture) {
+      display: none;
+    }
+  }
+
+  & > svg {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
 }
 
 #feature-info {

--- a/views/base.html
+++ b/views/base.html
@@ -35,8 +35,7 @@
         }
     </style>
 </head>
-<body class="d-flex h-100 text-bg-dark">
-    <div class="cover-container d-flex w-100 h-100 mx-auto flex-column">
+<body>
         <header class="mb-auto">
             <div>
                 <nav class="navbar navbar-expand-lg navbar-dark bg-primary faction-background-color">
@@ -116,10 +115,9 @@
                 </nav>
             </div>
         </header>
-        <main class="px-3" style="height: calc(100% - 56px);">
+        <main>
             {% block content %}{% endblock %}
         </main>
-    </div>
 
     <script src="/dist/main.js?{{ cacheBuster }}"></script>
     {% block javascript %}{% endblock %}

--- a/views/stats.html
+++ b/views/stats.html
@@ -11,6 +11,12 @@
 {% block content %}
 <div id="map" class="h-100 w-100">
 </div>
+<button type="button" id="pip-button" aria-label="Picture-In-Picture Mode">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path fill="currentColor"
+      d="M3 11q-.425 0-.712-.288T2 10t.288-.712T3 9h2.6L2 5.425q-.3-.3-.3-.712T2 4t.713-.3t.712.3L7 7.6V5q0-.425.288-.712T8 4t.713.288T9 5v5q0 .425-.288.713T8 11zm1 9q-.825 0-1.412-.587T2 18v-4q0-.425.288-.712T3 13t.713.288T4 14v4h7q.425 0 .713.288T12 19t-.288.713T11 20zm17-7q-.425 0-.712-.288T20 12V6h-8q-.425 0-.712-.288T11 5t.288-.712T12 4h8q.825 0 1.413.588T22 6v6q0 .425-.288.713T21 13m-6 7q-.425 0-.712-.288T14 19v-3q0-.425.288-.712T15 15h6q.425 0 .713.288T22 16v3q0 .425-.288.713T21 20z" />
+  </svg>
+</button>
 <!--<div id="global-alerts">-->
 <!--    <div id="disconnected" class="alert alert-danger mb-2">Connection to server lost. Auto-reconnect in 10s. Map doesn't-->
 <!--        update automatically. Editing not possible. Refresh page if message doesn't disappear.</div>-->


### PR DESCRIPTION
Trying out the PIP support in Chrome/Edge, this adds a button that will only appear if the users browser supports the functionality, also got around the weird layout shift when the user closes the PIP window.

This PR is only to merge to dev since I want to make sure it's not breaking any other layouts first.