### PR TITLE
Fixes flags

### DIFF
--- a/frontend/flags.ts
+++ b/frontend/flags.ts
@@ -189,11 +189,19 @@ export class Flags {
         return feature;
       }
     }
-    feature = this.tools.line.allLinesCollection.getFeatureById(id);
+    this.tools.line.allLinesCollection.forEach((line) => {
+      if (line.getId() === id) {
+        feature = line;
+      }
+    });
     if (feature) {
       return feature;
     }
     feature = this.tools.polygon.source.getFeatureById(id);
+    if (feature) {
+      return feature;
+    }
+    feature = this.tools.rectangle.source.getFeatureById(id);
     if (feature) {
       return feature;
     }


### PR DESCRIPTION
Flagging didnt work for lines, rectangles and polygons.
This was caused by getFeatureByID being called on allLinesCollection which wasnt valid and that canceling the function before ever getting to the search for polygons. 
Rectangles were just completely missing.
This fixes the search for lines and adds a search for rectangles on findFeature in flags.ts