### PR TITLE
Auto expiring icons

### DIFF
--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -266,3 +266,8 @@ button.overlay-button {
   animation: blink-red 0.4s ease-in-out 2;
   border-color: red;
 }
+
+.input-2digit {
+  width: 7ch;
+  text-align: left;
+}

--- a/frontend/tools/icon.ts
+++ b/frontend/tools/icon.ts
@@ -116,6 +116,7 @@ class Icon {
       feature.set('icon', this.featureIcon, true);
       feature.set('type', this.featureType, true)
       feature.set('notes', tools.sidebar.notesInput.value)
+      feature.set("expireTime", tools.sidebar.getExpireTime())
       this.unselectIcon()
       tools.emit(tools.EVENT_ICON_ADDED, feature)
     })

--- a/frontend/tools/icon.ts
+++ b/frontend/tools/icon.ts
@@ -117,6 +117,7 @@ class Icon {
       feature.set('type', this.featureType, true)
       feature.set('notes', tools.sidebar.notesInput.value)
       feature.set("expireTime", tools.sidebar.getExpireTime())
+      feature.set("expireDate", tools.sidebar.getExpireDate(feature.get("expireTime")))
       this.unselectIcon()
       tools.emit(tools.EVENT_ICON_ADDED, feature)
     })

--- a/frontend/tools/line.ts
+++ b/frontend/tools/line.ts
@@ -93,6 +93,7 @@ class Line {
       event.feature.set('clan', tools.sidebar.clanInput.value, true)
       event.feature.set('lineType', tools.sidebar.lineTypeInput.value)
       event.feature.set("expireTime", tools.sidebar.getExpireTime())
+      event.feature.set("expireDate", tools.sidebar.getExpireDate(event.feature.get("expireTime")))
       this.sketchFeature = null
       tools.emit(tools.EVENT_ICON_ADDED, event.feature)
     })

--- a/frontend/tools/line.ts
+++ b/frontend/tools/line.ts
@@ -92,6 +92,7 @@ class Line {
       event.feature.set('color', tools.sidebar.colorInput.value, true)
       event.feature.set('clan', tools.sidebar.clanInput.value, true)
       event.feature.set('lineType', tools.sidebar.lineTypeInput.value)
+      event.feature.set("expireTime", tools.sidebar.getExpireTime())
       this.sketchFeature = null
       tools.emit(tools.EVENT_ICON_ADDED, event.feature)
     })

--- a/frontend/tools/polygon.ts
+++ b/frontend/tools/polygon.ts
@@ -76,6 +76,7 @@ class Polygon {
       feature.set('color', tools.sidebar.colorInput.value + 'AA', true)
       feature.set('notes', tools.sidebar.notesInput.value)
       feature.set("expireTime", tools.sidebar.getExpireTime())
+      feature.set("expireDate", tools.sidebar.getExpireDate(feature.get("expireTime")))
       tools.emit(tools.EVENT_ICON_ADDED, feature)
       tools.changeTool(false)
       this.sketchFeature = null

--- a/frontend/tools/polygon.ts
+++ b/frontend/tools/polygon.ts
@@ -75,6 +75,7 @@ class Polygon {
       feature.set('type', 'polygon', true)
       feature.set('color', tools.sidebar.colorInput.value + 'AA', true)
       feature.set('notes', tools.sidebar.notesInput.value)
+      feature.set("expireTime", tools.sidebar.getExpireTime())
       tools.emit(tools.EVENT_ICON_ADDED, feature)
       tools.changeTool(false)
       this.sketchFeature = null

--- a/frontend/tools/rectangle.ts
+++ b/frontend/tools/rectangle.ts
@@ -61,6 +61,7 @@ class Rectangle {
       feature.set('color', tools.sidebar.colorInput.value + this.opacity, true)
       feature.set('secondary-color', tools.sidebar.secondaryColorInput.value + this.opacity, true)
       feature.set('notes', tools.sidebar.notesInput.value)
+      feature.set("expireTime", tools.sidebar.getExpireTime())
       tools.emit(tools.EVENT_ICON_ADDED, feature)
       tools.changeTool(false)
       this.sketchFeature = null
@@ -128,6 +129,8 @@ class Rectangle {
       }
     })
   }
+
+  
 
   toolSelected = () => {
     this.map.addInteraction(this.draw)

--- a/frontend/tools/rectangle.ts
+++ b/frontend/tools/rectangle.ts
@@ -62,6 +62,7 @@ class Rectangle {
       feature.set('secondary-color', tools.sidebar.secondaryColorInput.value + this.opacity, true)
       feature.set('notes', tools.sidebar.notesInput.value)
       feature.set("expireTime", tools.sidebar.getExpireTime())
+      feature.set("expireDate", tools.sidebar.getExpireDate(feature.get("expireTime")))
       tools.emit(tools.EVENT_ICON_ADDED, feature)
       tools.changeTool(false)
       this.sketchFeature = null

--- a/frontend/tools/select.ts
+++ b/frontend/tools/select.ts
@@ -9,6 +9,7 @@ import { Vector as VectorSource } from "ol/source.js";
 import { Circle, Fill, Stroke, Style } from "ol/style.js";
 
 import { ACL_ACTIONS } from "../../lib/ACLS.js";
+import { diff } from "util";
 
 
 const NO_TOOLTIP = ['Region', 'Major', 'Minor', 'voronoi', 'radius', 'grid', 'obsTowerRadius']
@@ -203,7 +204,7 @@ class Select {
 
     tools.on(tools.EVENT_DECAY_UPDATED, (data) => {
       if (data.id in this.clocks) {
-        this.setClockColor(this.clocks[data.id], new Date(data.time))
+        this.setClockColor(this.clocks[data.id], data.expireTime, new Date(data.expireDate))
       }
     })
 
@@ -453,27 +454,37 @@ class Select {
   }
 
   clockColor = (clock, feature) => {
-    if (NO_CLOCK.includes(feature.get('type'))) {
-      clock.style.display = 'none'
+    if (!feature.get("expireDate") || new Date(feature.get("expireDate")).getTime() <= 0) {
+      clock.querySelector("svg").style.display = 'none'
+      clock.querySelector(".clock-time").display = ''
+      this.roundedTimeText(clock, new Date(feature.get('time')).getTime() - new Date().getTime())
       return
     }
-    clock.style.display = ''
-    const time = new Date(feature.get('time'))
+    clock.querySelector("svg").style.display = ''
+    const expDate = new Date(feature.get('expireDate'))
+    const time = feature.get('expireTime')
     clock.dataset.id = feature.getId() || null
     clock.dataset.type = feature.get('type') || null
-    this.setClockColor(clock, time)
+    this.setClockColor(clock, time, expDate)
   }
 
-  setClockColor = (clock, time) => {
-    const diff = new Date().getTime() - time.getTime()
-    clock.getElementsByTagName('circle')[0].style.fill = this.getColorForPercentage((24 - diff / 3600000) / 24)
-    clock.title = time.toLocaleString();
-    if (diff < 3600000) {
-      clock.getElementsByClassName('clock-time')[0].innerHTML = this.relativeTimeFormat.format(Math.round(-diff / 60000), 'minute')
-    } else if (diff < 86400000) {
-      clock.getElementsByClassName('clock-time')[0].innerHTML = this.relativeTimeFormat.format(Math.round(-diff / 3600000), 'hour')
-    } else {
-      clock.getElementsByClassName('clock-time')[0].innerHTML = this.relativeTimeFormat.format(Math.round(-diff / 86400000), 'day')
+  setClockColor = (clock, time, expDate) => {
+    const diff =  expDate.getTime() - new Date().getTime()
+    clock.getElementsByTagName('circle')[0].style.fill = this.getColorForPercentage(diff / time)
+    this.roundedTimeText(clock, diff, "Expires ")
+  
+  }
+
+  roundedTimeText = (clock, diff, text = "") => {
+    if (diff) {
+        const diffP = diff < 0 ? -diff : diff
+        if (diffP < 3600000) {
+        clock.getElementsByClassName('clock-time')[0].innerHTML = text + this.relativeTimeFormat.format(Math.round(diff / 60000), 'minute')
+      } else if (diffP < 86400000) {
+        clock.getElementsByClassName('clock-time')[0].innerHTML = text + this.relativeTimeFormat.format(Math.round(diff / 3600000), 'hour')
+      } else {
+        clock.getElementsByClassName('clock-time')[0].innerHTML = text + this.relativeTimeFormat.format(Math.round(diff / 86400000), 'day')
+      }
     }
   }
 

--- a/frontend/tools/sidebar.ts
+++ b/frontend/tools/sidebar.ts
@@ -314,7 +314,7 @@ class Sidebar {
     if (active.id === "expire-preset") {
       const time = Number(active.querySelector("input:checked")?.id) || 0;
 
-      return new Date(Date.now() + Number(time)).toISOString();
+      return time;
     }
 
     if (active.id === "expire-custom") {
@@ -330,7 +330,7 @@ class Sidebar {
 
       const time = Number(actualValue) * multiplier || 0;
 
-      return new Date(Date.now() + Number(time)).toISOString();
+      return Number(time);
     }
 
     return 0;

--- a/frontend/tools/sidebar.ts
+++ b/frontend/tools/sidebar.ts
@@ -54,6 +54,7 @@ class Sidebar {
     const secondaryColorPicker = document.getElementById('secondary-color-picker')
     const defaultColor = localStorage.getItem('defaultColor');
     const secondaryDefaultColor = localStorage.getItem('secondaryDefaultColor');
+
     if (defaultColor) {
       this.colorInput.value = defaultColor;
     }
@@ -148,7 +149,25 @@ class Sidebar {
       })
     }
     this.tools.on(this.tools.EVENT_TOOL_SELECTED, this.selectTool)
+
+    document.getElementById('expire-toggle').addEventListener('click', () => {
+      const expireCustomToggle = document.getElementById('expire-toggle');
+      const expirePreset = document.getElementById('expire-preset');
+      const expireCustom = document.getElementById('expire-custom');
+      const isCustom = expirePreset.classList.contains('d-none')
+      if (isCustom) {
+        expirePreset.classList.remove('d-none')
+        expireCustom.classList.add('d-none')
+        expireCustomToggle.textContent = 'Custom'
+      } else {
+        expirePreset.classList.add('d-none')
+        expireCustom.classList.remove('d-none')
+        expireCustomToggle.textContent = 'Preset'
+      }
+    })
   }
+
+  
 
   rgb2hex = (rgb) => {
     function hex(x) {

--- a/frontend/tools/sidebar.ts
+++ b/frontend/tools/sidebar.ts
@@ -48,6 +48,7 @@ class Sidebar {
     this.secondaryColorInput = document.getElementById('secondary-color-input')
     this.notesInput = document.getElementById('notes-input')
     this.buttonRow = document.getElementById('button-row')
+    this.expireInputs = document.getElementById('expire-inputs')?.querySelectorAll('input, select, button')
     this.displayForm(['notes'])
 
     const colorPicker = document.getElementById('color-picker')
@@ -157,11 +158,15 @@ class Sidebar {
       const isCustom = expirePreset.classList.contains('d-none')
       if (isCustom) {
         expirePreset.classList.remove('d-none')
+        expirePreset.classList.add('active')
         expireCustom.classList.add('d-none')
+        expireCustom.classList.remove('active')
         expireCustomToggle.textContent = 'Custom'
       } else {
         expirePreset.classList.add('d-none')
+        expirePreset.classList.remove('active')
         expireCustom.classList.remove('d-none')
+        expireCustom.classList.add('active')
         expireCustomToggle.textContent = 'Preset'
       }
     })
@@ -254,6 +259,7 @@ class Sidebar {
     if (this.editFeature) {
       this.tools.emit(this.tools.EVENT_UPDATE_CANCELED, this.editFeature)
       this.buttonRow.style.display = 'none'
+      this.expireInputs.forEach(input => {input.disabled = false}); 
     }
   }
 
@@ -264,6 +270,7 @@ class Sidebar {
     this.secondaryColorInput.parentElement.parentElement.style.display = visibleFields.includes('secondaryColor') ? '' : 'none'
     this.notesInput.parentElement.parentElement.style.display = visibleFields.includes('notes') ? '' : 'none'
     this.buttonRow.style.display = this.editFeature ? '' : 'none'
+    this.expireInputs.forEach(input => {input.disabled = this.editFeature ? true : false}) 
   }
 
   setAcl = (acl) => {
@@ -298,6 +305,37 @@ class Sidebar {
     val = val == null ? '' : '' + val;
     return val.replace(RegExp('(?:' + Object.keys(replace).join('|') + ')', 'g'), function (m) { return replace[m]; });
   }
+
+  getExpireTime() {
+    const active = document.getElementById("expire-input")?.querySelector(".active");
+
+    if (!active || active.querySelector("input").disabled) return 0;
+
+    if (active.id === "expire-preset") {
+      const time = Number(active.querySelector("input:checked")?.id) || 0;
+
+      return new Date(Date.now() + Number(time)).toISOString();
+    }
+
+    if (active.id === "expire-custom") {
+      const inputValue = document.getElementById("custom-expire-input")?.value;
+      const actualValue = Number(inputValue > 999 ? 0 : inputValue ) || 0; 
+      const unit = document.getElementById("custom-expire-unit")?.value;
+
+      let multiplier = 1;
+
+      if (unit === "minutes") multiplier = 60000;
+      else if (unit === "hours") multiplier = 3600000;
+      else if (unit === "days") multiplier = 86400000;
+
+      const time = Number(actualValue) * multiplier || 0;
+
+      return new Date(Date.now() + Number(time)).toISOString();
+    }
+
+    return 0;
+  }
+
 }
 
 export default Sidebar

--- a/frontend/tools/sidebar.ts
+++ b/frontend/tools/sidebar.ts
@@ -336,6 +336,13 @@ class Sidebar {
     return 0;
   }
 
+  getExpireDate(ms) {
+    if (!ms) return null;
+
+    const expireDate = new Date(Date.now() + ms);
+    return expireDate.toISOString();
+  }
+
 }
 
 export default Sidebar

--- a/lib/featureLoader.js
+++ b/lib/featureLoader.js
@@ -58,6 +58,8 @@ export function saveFeatures(features) {
  * User Map Feature Properties
  * @typedef {object} UserMapFeatureProperties
  * @property {string} [time]
+ * @property {string} [creationTime]
+ * @property {string} [expireTime]
  * @property {string} user
  * @property {string} userId
  * @property {?string} discordId

--- a/lib/featureLoader.js
+++ b/lib/featureLoader.js
@@ -58,8 +58,8 @@ export function saveFeatures(features) {
  * User Map Feature Properties
  * @typedef {object} UserMapFeatureProperties
  * @property {string} [time]
- * @property {string} [creationTime]
- * @property {string} [expireTime]
+ * @property {string} [expireDate]
+ * @property {number} [expireTime]
  * @property {string} user
  * @property {string} userId
  * @property {?string} discordId

--- a/views/help.html
+++ b/views/help.html
@@ -104,10 +104,9 @@
         <div class="container-fluid py-5">
             <h1 class="display-5 fw-bold">Help</h1>
             <h2>Decay Information</h2>
-            <p>Inside Info boxes there is a Decay notification (<span id="clock" class="clock">{% include 'clock.svg' %}</span>).</p>
+            <p>If an expiration time was selected a clock will show in the info box of the corresponding feature (<span id="clock" class="clock">{% include 'clock.svg' %}</span>).</p>
     <!--        <table id="test"></table>-->
-            <p>This goes from green (just placed) over yellow (updated 12h ago) to red (updated 24h ago).</p>
-            <p>Hovering over the element will show the exact time (select an element before to be able to hover).</p>
+            <p>This goes from green (just placed) to red (about to expire).</p>
             <p>Clicking on it will reset the timer.</p>
             <h2>Read/Edit Mode</h2>
             <p>Depending on permission you have access to use the edit mode (<i class="bi bi-gear"></i>)</p>

--- a/views/sidebar-edit.html
+++ b/views/sidebar-edit.html
@@ -65,6 +65,25 @@
                     <textarea id="notes-input" name="notes" class="notes form-control"></textarea>
                 </div>
             </div>
+            <div class="row mb-2 align-items-center py-1">
+                <div class="col-3">
+                    <span>Expires in</span>
+                </div>
+                <div class="col-9">
+                    <div class="d-flex flex-wrap align-items-center gap-3">
+
+                    <div class="d-flex align-items-center gap-2">
+
+                        <input type="number" class="form-control form-control-sm input-2digit" id="expire-time-days" min="0" max="30" step="1">
+                        <label for="expire-time-days" class="mb-0">days and</label>
+
+                        <input type="number" class="form-control form-control-sm input-2digit" id="expire-time-hours" min="0" max="23" step="1">
+                        <label for="expire-time-hours" class="mb-0">hours</label>
+                    </div>
+
+                    </div>
+                </div>
+            </div>
             <div class="row mb-2" id="button-row">
                 <div class="btn-group col-sm-12">
                     <input type="submit" id="delete-button" value="Delete" name="delete"

--- a/views/sidebar-edit.html
+++ b/views/sidebar-edit.html
@@ -69,21 +69,41 @@
                 <div class="col-3">
                     <span>Expires in</span>
                 </div>
-                <div class="col-9">
-                    <div class="d-flex flex-wrap align-items-center gap-3">
+                <div class="col-6">
+                    <div class="btn-group btn-group-sm" role="group" id="expire-preset">
+                        <input type="radio" class="btn-check" name="expire" id="exp-never" checked>
+                        <label class="btn btn-outline-light" for="exp-never">Never</label>
 
-                    <div class="d-flex align-items-center gap-2">
+                        <input type="radio" class="btn-check" name="expire" id="exp-1h">
+                        <label class="btn btn-outline-light" for="exp-1h">1h</label>
 
-                        <input type="number" class="form-control form-control-sm input-2digit" id="expire-time-days" min="0" max="30" step="1">
-                        <label for="expire-time-days" class="mb-0">days and</label>
+                        <input type="radio" class="btn-check" name="expire" id="exp-6h">
+                        <label class="btn btn-outline-light" for="exp-6h">6h</label>
 
-                        <input type="number" class="form-control form-control-sm input-2digit" id="expire-time-hours" min="0" max="23" step="1">
-                        <label for="expire-time-hours" class="mb-0">hours</label>
+                        <input type="radio" class="btn-check" name="expire" id="exp-1d">
+                        <label class="btn btn-outline-light" for="exp-1d">1d</label>
+
+                        <input type="radio" class="btn-check" name="expire" id="exp-7d">
+                        <label class="btn btn-outline-light" for="exp-7d">7d</label>
+
                     </div>
-
+                    <div class="d-flex align-items-start gap-3 d-none" id="expire-custom">
+                        <input type="number" id="custom-expire-input" class="form-control form-control-sm" min="1" max="60" value="10" title="expire value">
+                        <select id="custom-expire-unit" class="form-select form-select-sm w-auto" title="expire unit">
+                            <option>minutes</option>
+                            <option>hours</option>
+                            <option>days</option>
+                        </select>
                     </div>
                 </div>
+                <div class="col-3">
+                    <button class="btn btn-outline-light btn-sm" id="expire-toggle" type="button">
+                    Custom
+                    </button>
+                </div>
+                 
             </div>
+            
             <div class="row mb-2" id="button-row">
                 <div class="btn-group col-sm-12">
                     <input type="submit" id="delete-button" value="Delete" name="delete"

--- a/views/sidebar-edit.html
+++ b/views/sidebar-edit.html
@@ -65,26 +65,26 @@
                     <textarea id="notes-input" name="notes" class="notes form-control"></textarea>
                 </div>
             </div>
-            <div class="row mb-2 align-items-center py-1">
+            <div class="row mb-2 align-items-center py-1" id="expire-inputs">
                 <div class="col-3">
                     <span>Expires in</span>
                 </div>
-                <div class="col-6">
-                    <div class="btn-group btn-group-sm" role="group" id="expire-preset">
+                <div id="expire-input" class="col-6">
+                    <div class="btn-group btn-group-sm active" role="group" id="expire-preset">
                         <input type="radio" class="btn-check" name="expire" id="exp-never" checked>
                         <label class="btn btn-outline-light" for="exp-never">Never</label>
 
-                        <input type="radio" class="btn-check" name="expire" id="exp-1h">
-                        <label class="btn btn-outline-light" for="exp-1h">1h</label>
+                        <input type="radio" class="btn-check" name="expire" id="3600000">
+                        <label class="btn btn-outline-light" for="3600000">1h</label>
 
-                        <input type="radio" class="btn-check" name="expire" id="exp-6h">
-                        <label class="btn btn-outline-light" for="exp-6h">6h</label>
+                        <input type="radio" class="btn-check" name="expire" id="21600000">
+                        <label class="btn btn-outline-light" for="21600000">6h</label>
 
-                        <input type="radio" class="btn-check" name="expire" id="exp-1d">
-                        <label class="btn btn-outline-light" for="exp-1d">1d</label>
+                        <input type="radio" class="btn-check" name="expire" id="86400000">
+                        <label class="btn btn-outline-light" for="86400000">1d</label>
 
-                        <input type="radio" class="btn-check" name="expire" id="exp-7d">
-                        <label class="btn btn-outline-light" for="exp-7d">7d</label>
+                        <input type="radio" class="btn-check" name="expire" id="604800000">
+                        <label class="btn btn-outline-light" for="604800000">7d</label>
 
                     </div>
                     <div class="d-flex align-items-start gap-3 d-none" id="expire-custom">
@@ -100,8 +100,7 @@
                     <button class="btn btn-outline-light btn-sm" id="expire-toggle" type="button">
                     Custom
                     </button>
-                </div>
-                 
+                </div>  
             </div>
             
             <div class="row mb-2" id="button-row">

--- a/websocket.js
+++ b/websocket.js
@@ -508,15 +508,18 @@ function checkExpiredFeatures() {
   setTimeout(() => {
     checkedExpiredRecently = false;
   }, 60_000)
+
+  const now = Date.now();
+
   for (const featureToCheck of features.features) {
 
-    const expireTime = featureToCheck.properties?.expireTime;
+    const expireTime = new Date(featureToCheck.properties?.expireTime || -(now + 1)).getTime() + now;
 
-    if (expireTime && (new Date(expireTime).getTime() >= Date.now() || new Date(expireTime).getTime() <= 0 )) {
+    if (expireTime >= now || expireTime <= 0 ) {
       continue
     }
     
-    if (expireTime && new Date(expireTime).getTime() < Date.now()) {
+    if (expireTime < now) {
       features.features = features.features.filter((feature) => {
         return feature.properties.id !== featureToCheck.properties.id
       })

--- a/websocket.js
+++ b/websocket.js
@@ -472,6 +472,7 @@ function sendData(client, type, data) {
  * @param {string} newHash 
  */
 function sendUpdateFeature(operation, feature, oldHash, newHash) {
+  checkExpiredFeatures()
   sendDataToAll('featureUpdate', {
     operation,
     feature,
@@ -493,7 +494,37 @@ function sendFeaturesToAll() {
  * @param {WebSocket} client 
  */
 function sendFeatures(client) {
+  checkExpiredFeatures()
   sendData(client, 'allFeatures', features)
+}
+
+let checkedExpiredRecently = false;
+
+function checkExpiredFeatures() {
+  if (checkedExpiredRecently) {
+    return;
+  }
+  checkedExpiredRecently = true;
+  setTimeout(() => {
+    checkedExpiredRecently = false;
+  }, 60_000)
+  for (const featureToCheck of features.features) {
+
+    const expireTime = featureToCheck.properties?.expireTime;
+
+    if (expireTime && (new Date(expireTime).getTime() >= Date.now() || new Date(expireTime).getTime() <= 0 )) {
+      continue
+    }
+    
+    if (expireTime && new Date(expireTime).getTime() < Date.now()) {
+      features.features = features.features.filter((feature) => {
+        return feature.properties.id !== featureToCheck.properties.id
+      })
+    const oldHash = features.hash
+    saveFeatures(features)
+    sendUpdateFeature('delete', featureToCheck, oldHash, features.hash)
+    }
+  }
 }
 
 /**

--- a/websocket.js
+++ b/websocket.js
@@ -292,6 +292,8 @@ wss.on('connection', function (ws, request) {
           for (const feature of features.features) {
             if (feature.properties.id === content.data.id) {
               const newTime = (new Date()).toISOString();
+              const newExpireDate = new Date(new Date().getTime() + (feature.properties.expireTime || -(new Date().getTime() + 1))).toISOString()
+              feature.properties.expireDate = newExpireDate
               feature.properties.time = newTime;
               feature.properties.muser = username
               feature.properties.muserId = userId
@@ -300,6 +302,8 @@ wss.on('connection', function (ws, request) {
                 id: feature.properties.id,
                 type: feature.properties.type,
                 time: newTime,
+                expireDate: newExpireDate,
+                expireTime: feature.properties.expireTime,
               })
             }
           }
@@ -497,31 +501,24 @@ function sendFeatures(client) {
 }
 
 function checkExpiredFeatures() {
-  if (checkedExpiredRecently) {
-    return;
-  }
-  checkedExpiredRecently = true;
-  setTimeout(() => {
-    checkedExpiredRecently = false;
-  }, 60_000)
 
   const now = Date.now();
 
   for (const featureToCheck of features.features) {
 
-    const expireTime = new Date(featureToCheck.properties?.expireTime || -(now + 1)).getTime() + now;
+    const expireDate = new Date(featureToCheck.properties?.expireDate || -1).getTime();
 
-    if (expireTime >= now || expireTime <= 0 ) {
+    if (expireDate >= now || expireDate <= 0 ) {
       continue
     }
     
-    if (expireTime < now) {
+    if (expireDate < now) {
       features.features = features.features.filter((feature) => {
         return feature.properties.id !== featureToCheck.properties.id
       })
     const oldHash = features.hash
-    saveFeatures(features)
     sendUpdateFeature('delete', featureToCheck, oldHash, features.hash)
+    saveFeatures(features)
     }
   }
 }
@@ -721,6 +718,8 @@ export default function startServer (server) {
  * @property {string} id
  * @property {string} type
  * @property {string} time
+ * @property {string} expireDate
+ * @property {number | undefined} expireTime
  */
 
 /**

--- a/websocket.js
+++ b/websocket.js
@@ -472,7 +472,6 @@ function sendData(client, type, data) {
  * @param {string} newHash 
  */
 function sendUpdateFeature(operation, feature, oldHash, newHash) {
-  checkExpiredFeatures()
   sendDataToAll('featureUpdate', {
     operation,
     feature,
@@ -494,20 +493,11 @@ function sendFeaturesToAll() {
  * @param {WebSocket} client 
  */
 function sendFeatures(client) {
-  checkExpiredFeatures()
   sendData(client, 'allFeatures', features)
 }
 
-let checkedExpiredRecently = false;
-
 function checkExpiredFeatures() {
-  if (checkedExpiredRecently) {
-    return;
-  }
-  checkedExpiredRecently = true;
-  setTimeout(() => {
-    checkedExpiredRecently = false;
-  }, 60_000)
+  
   for (const featureToCheck of features.features) {
 
     const expireTime = featureToCheck.properties?.expireTime;
@@ -538,6 +528,7 @@ async function conquerUpdater() {
       return await updateMap()
     })
     .then((data) => {
+      checkExpiredFeatures()
       if (data) {
         const payload = Object.assign(data, { oldVersion, warNumber: warapi.warData.warNumber })
         sendDataToAll('conquer', payload)


### PR DESCRIPTION
When a new feature is added the user can choose between a few presets of time until expiration or can enter a custom time.
I did not see a good way to implement users updating the time until expiration after the feature is already created without making the UI either misleading or cluttered, so for now when editing a feature the expiring section is disabled.