### PR TITLE
Invisible line bug

### DIFF
--- a/frontend/tools/line.ts
+++ b/frontend/tools/line.ts
@@ -260,9 +260,6 @@ class Line {
 
   toolDeSelected = () => {
     if (this.draw) {
-      if (this.draw.getActive()) {
-        this.draw.finishDrawing()
-      }
       this.map.removeInteraction(this.draw)
       this.map.removeInteraction(this.snap)
     }


### PR DESCRIPTION
On canceling line drawing it would automatically finish. On a line with only one point this would create an invisible feature.
If we want to keep the functionality that a line is finished when drawing is canceled this can also be fixed by just putting
`this.sketchFeature.getGeometry().getCoordinates().length > 2`
into the if check before finishing drawing, as we dont do it this way on rectangles or polygons and I dont think its generally the intention of the user when canceling draw mode or selecting another tool to finish their line, I would leave it as it is with this change.